### PR TITLE
Fix: dock stuck hidden forever when a desktop-icons window is present (DING/similar)

### DIFF
--- a/src/core/autohide/AutoHideAnimations.js
+++ b/src/core/autohide/AutoHideAnimations.js
@@ -239,7 +239,9 @@ export function animateHide(ahm) {
     ahm._applyDockInputState(false);
 
     ahm.dockUI.actor.remove_all_transitions();
-    ahm._setAutoHideMagnifierPaused(true);
+    try {
+        ahm._setAutoHideMagnifierPaused(true);
+    } catch {}
 
     const pos = ahm._getDockPosition();
     const offset = (ahm.settings.get_int('dock-margin') || 0) + 80;

--- a/src/core/autohide/AutoHideManager.js
+++ b/src/core/autohide/AutoHideManager.js
@@ -291,9 +291,13 @@ export default class AutoHideManager {
         } else {
             shouldHide = anyOverlap;
         }
-
+        
         if (shouldHide) {
-            this._hide();
+            if (this.isHidden) {
+                if (!this._edgePointerPollId) this._startEdgePointerPoll();
+            } else {
+                this._hide();
+            }
         } else {
             this._show(false, true);
         }

--- a/src/core/autohide/AutoHideManager.js
+++ b/src/core/autohide/AutoHideManager.js
@@ -102,14 +102,13 @@ export default class AutoHideManager {
         const actualMonitor = monitorData.monitor;
         const activeWs = global.workspace_manager.get_active_workspace();
 
-        if (activeWs) {
-            for (const win of activeWs.list_windows()) {
-                if (!win || win.minimized || win.get_monitor() !== dockMonitorIndex) continue;
-                if (win.is_fullscreen()) return true;
+        for (const win of activeWs.list_windows()) {
+            if (!win || win.minimized || win.get_monitor() !== dockMonitorIndex) continue;
+            if (win.get_window_type() === Meta.WindowType.DESKTOP) continue;   // <-- aggiungi questa riga
+            if (win.is_fullscreen()) return true;
 
-                const r = win.get_frame_rect();
-                if (r.width >= actualMonitor.width - 2 && r.height >= actualMonitor.height - 30) return true;
-            }
+            const r = win.get_frame_rect();
+            if (r.width >= actualMonitor.width - 2 && r.height >= actualMonitor.height - 30) return true;
         }
 
         const focusWin = global.display.get_focus_window();

--- a/src/ui/magnifier/Magnifier.js
+++ b/src/ui/magnifier/Magnifier.js
@@ -34,9 +34,16 @@ const FLIP_DURATION = 300;
 const TOOLTIP_DELAY_MS = 600;
 
 function isActorAlive(actor) {
-    if (!actor) return false;
-    return actor.visible !== undefined;
+    if (!actor)
+        return false;
+
+    try {
+        return actor.visible !== undefined;
+    } catch (e) {
+        return false;
+    }
 }
+
 
 export function applyRealtimeFrame(dockActor, cx, cy, isVertical, settings, now = null) {
     if (!dockActor || dockActor._isHidden || !dockActor.visible || dockActor._suppressZoom) {

--- a/src/ui/magnifier/MagnifierTooltipRenderer.js
+++ b/src/ui/magnifier/MagnifierTooltipRenderer.js
@@ -31,8 +31,14 @@ import { TimeoutTracker } from '../../core/TimeoutTracker.js';
 
 
 function isActorAlive(actor) {
-    if (!actor) return false;
-    return actor.visible !== undefined;
+    if (!actor)
+        return false;
+
+    try {
+        return actor.visible !== undefined;
+    } catch (e) {
+        return false;
+    }
 }
 
 export function createWindowControl(iconName, rgbColor, onClick, bindObj) {


### PR DESCRIPTION
Fixes #47

## Root cause

`_isFullscreenActive()` in AutoHideManager.js walks every window on the
active workspace and treats anything covering the whole monitor as
"fullscreen":

    for (const win of activeWs.list_windows()) {
        if (!win || win.minimized || win.get_monitor() !== dockMonitorIndex) continue;
        if (win.is_fullscreen()) return true;

        const r = win.get_frame_rect();
        if (r.width >= actualMonitor.width - 2 && r.height >= actualMonitor.height - 30) return true;
    }

Extensions like Desktop Icons NG (DING) create a permanent window the
size of the monitor to draw desktop icons. That window is picked up by
this check and makes `_isFullscreenActive()` return `true`
*permanently*, even with zero real fullscreen windows open.

This breaks both reveal paths at once:

- The edge-hover polling fallback (`EdgeDetection.js`,
  `startEdgePointerPoll`) refuses to even start once the dock hides,
  since it early-returns on `ahm._isFullscreenActive()`.
- The native `enter-event` handler on the edge trigger
  (`AutoHideManager.js`) also bails out early for the same reason:

      'enter-event', () => {
          if (!this.isHidden || this._isFullscreenActive()) return Clutter.EVENT_PROPAGATE;

So once the dock auto-hides, *nothing* can bring it back via hover —
only paths that don't consult `_isFullscreenActive()` at all (like
opening the overview) still work, which matches what was reported.

Confirmed by adding temporary logging around both reveal paths: every
single attempt logged `fullscreen rilevato` / fullscreen detected,
with no real fullscreen window open — just a desktop-icons window
sitting on the monitor.

## Fix

Skip windows of type `DESKTOP` in the fullscreen scan:

    for (const win of activeWs.list_windows()) {
        if (!win || win.minimized || win.get_monitor() !== dockMonitorIndex) continue;
        if (win.get_window_type() === Meta.WindowType.DESKTOP) continue;
        if (win.is_fullscreen()) return true;
        ...

`Meta` is already imported in this file. Verified with logging that
the poll now starts normally (`poll avviato correttamente`) instead of
bailing out, and the dock reliably reappears on hover after auto-hide.

This likely explains why it couldn't be reproduced upstream — it only
shows up with a desktop-icons extension (DING or similar) active,
which isn't part of a default GNOME Shell setup.

## Bonus fix (found while debugging, unrelated to the main issue)

While chasing this, journalctl also showed a real (but separate) crash:

    Object St.Bin (0x...), has been already disposed — impossible to
    get any property from it.
    MagnifierTooltipRenderer.js:35 / :291
    TimeoutTracker.js:29

`isActorAlive()` is meant to safely check whether an actor is still
valid, but reading a property on a disposed GJS-wrapped actor throws
instead of returning `undefined`, so the safety check itself was
crashing. Wrapped it in try/catch in both places it's duplicated
(`MagnifierTooltipRenderer.js` and `Magnifier.js`). This didn't turn
out to be the cause of #47, but it's a real bug worth fixing while
in the area.