### PR TITLE
fix: prevent use-after-dispose SIGSEGV with stolen external actors (#54)

### DIFF
--- a/src/core/DockManager.js
+++ b/src/core/DockManager.js
@@ -22,6 +22,7 @@ import Clutter from 'gi://Clutter';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 import { TimeoutTracker } from './TimeoutTracker.js';
+import { isActorAlive, markActorDisposed } from '../ui/dock/DockLayoutEngine.js';
 
 
 export default class DockManager {
@@ -89,6 +90,9 @@ export default class DockManager {
                 child._isModule;
 
             if (!isGnomeOrDhruva) {
+                if (!isActorAlive(child)) return false;
+                if (this._externalActors.has(child)) return true;
+
                 const parent = child.get_parent();
                 if (parent) {
                     parent.remove_child(child);
@@ -98,6 +102,22 @@ export default class DockManager {
                 child._dhruvaExternalOwner = this;
                 child._is3rdParty = true;
                 this._externalActors.add(child);
+
+                // The owning extension may dispose this actor at any time
+                // (e.g. Dynamic Music Pill recreates its pill when the MPRIS
+                // source changes). Drop our reference the moment Clutter
+                // starts tearing it down so no later render pass touches a
+                // disposed GObject (issue #54).
+                child.connectObject('destroy', () => {
+                    markActorDisposed(child);
+                    this._externalActors.delete(child);
+                    if (this.dockUI && this.dockUI.queueRender) {
+                        this.timers.addIdle(GLib.PRIORITY_DEFAULT_IDLE, () => {
+                            if (this.dockUI) this.dockUI.queueRender();
+                            return GLib.SOURCE_REMOVE;
+                        });
+                    }
+                }, this);
 
                 child._isStatic = true;
                 if (child.ease) {
@@ -120,7 +140,7 @@ export default class DockManager {
                 }
 
                 this.timers.addTimeout(GLib.PRIORITY_DEFAULT, 300, () => {
-                    if (child && this.dockUI && this.dockUI.isActorAlive(child)) {
+                    if (child && this.dockUI && isActorAlive(child)) {
                         if (child.remove_all_transitions) child.remove_all_transitions();
                         if (child.visible) child.opacity = 255;
                         child.scale_x = 1;
@@ -142,12 +162,19 @@ export default class DockManager {
                             return GLib.SOURCE_REMOVE;
                         }
 
-                        this._externalActors.forEach(ext => {
-                            if (ext && ext._is3rdParty && ext.visible !== undefined) {
+                        // Snapshot first: we may delete from the Set while iterating.
+                        Array.from(this._externalActors).forEach(ext => {
+                            if (!isActorAlive(ext)) {
+                                this._externalActors.delete(ext);
+                                return;
+                            }
+                            if (!ext._is3rdParty) return;
+
+                            try {
                                 let fullText = '';
 
                                 const collectText = (actor) => {
-                                    if (!actor || !actor.get_children) return;
+                                    if (!isActorAlive(actor) || !actor.get_children) return;
                                     actor.get_children().forEach(sub => {
                                         const t = (sub.get_text ? sub.get_text() : sub.text) || '';
                                         if (typeof t === 'string' && t.trim().length > 0) {
@@ -169,6 +196,10 @@ export default class DockManager {
                                 } else {
                                     if (!ext.visible) ext.show();
                                 }
+                            } catch (_e) {
+                                // Actor was disposed mid-walk; drop it and move on.
+                                markActorDisposed(ext);
+                                this._externalActors.delete(ext);
                             }
                         });
 
@@ -184,18 +215,22 @@ export default class DockManager {
         };
 
         const releaseExternalWidget = (child) => {
-            if (child && child._isExternal) {
-                this._externalActors.delete(child);
+            if (!child) return;
+            const wasTracked = this._externalActors.delete(child);
+            if (!wasTracked && !child._isExternal) return;
+
+            if (isActorAlive(child)) {
+                child.disconnectObject(this);
                 child._isExternal = false;
                 child._dhruvaExternalOwner = null;
                 child._is3rdParty = false;
+            }
 
-                if (this.dockUI && this.dockUI.queueRender) {
-                    this.timers.addIdle(GLib.PRIORITY_DEFAULT_IDLE, () => {
-                        if (this.dockUI) this.dockUI.queueRender();
-                        return GLib.SOURCE_REMOVE;
-                    });
-                }
+            if (this.dockUI && this.dockUI.queueRender) {
+                this.timers.addIdle(GLib.PRIORITY_DEFAULT_IDLE, () => {
+                    if (this.dockUI) this.dockUI.queueRender();
+                    return GLib.SOURCE_REMOVE;
+                });
             }
         };
 
@@ -219,7 +254,24 @@ export default class DockManager {
                     if (!stealExternalWidget(child)) _nativeOrigInsert(child, index);
                 };
                 origBox.remove_child = (child) => {
-                    _nativeOrigRemove(child);
+                    // A stolen actor is re-parented into Dhruva's dock box, but
+                    // its owner still believes it lives in the GNOME dash and
+                    // calls origBox.remove_child(actor) on teardown. Forwarding
+                    // that to the native remove on origBox hits
+                    // "clutter_actor_remove_child: assertion 'child->priv->parent
+                    // != NULL' failed" and then a NULL deref (SIGSEGV, #54).
+                    // Detach from the actor's *actual* parent instead.
+                    if (!isActorAlive(child)) {
+                        releaseExternalWidget(child);
+                        return;
+                    }
+
+                    const realParent = child.get_parent();
+                    if (realParent === origBox) {
+                        _nativeOrigRemove(child);
+                    } else if (realParent) {
+                        realParent.remove_child(child);
+                    }
                     releaseExternalWidget(child);
                 };
 
@@ -258,9 +310,11 @@ export default class DockManager {
         }
 
         if (originalBox && this._externalActors && this._externalActors.size > 0) {
-            this._externalActors.forEach(child => {
-                if (!child || child._dhruvaExternalOwner !== this) return;
-                if (child.visible === undefined) return;
+            Array.from(this._externalActors).forEach(child => {
+                if (!isActorAlive(child)) return;
+                if (child._dhruvaExternalOwner !== this) return;
+
+                child.disconnectObject(this);
 
                 const parent = child.get_parent();
                 if (parent) {
@@ -269,6 +323,7 @@ export default class DockManager {
 
                 child._isExternal = false;
                 child._dhruvaExternalOwner = null;
+                child._is3rdParty = false;
 
                 if (this._nativeOrigAdd && originalBox === this._hijackedOrigBox) {
                     this._nativeOrigAdd(child);

--- a/src/ui/dock/DockLayoutEngine.js
+++ b/src/ui/dock/DockLayoutEngine.js
@@ -20,9 +20,27 @@
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 
+// Actors whose owner already disposed them (Clutter 'destroy' seen).
+// JS expando props on a disposed GObject wrapper are not reliable, so track
+// disposal out-of-band in a WeakSet rather than tagging the actor itself.
+const _disposedActors = new WeakSet();
+
+export function markActorDisposed(actor) {
+    if (actor) _disposedActors.add(actor);
+}
+
 export function isActorAlive(actor) {
     if (!actor) return false;
-    return actor.visible !== undefined;
+    if (_disposedActors.has(actor)) return false;
+    try {
+        // GJS logs a critical (and, once finalized, throws) when a disposed
+        // GObject is touched. Treat either outcome as "dead" and never let it
+        // propagate into a render pass.
+        if (typeof actor.get_parent !== 'function') return false;
+        return actor.visible !== undefined;
+    } catch (_e) {
+        return false;
+    }
 }
 
 export function captureActorRect(dockUI, actor, fallbackWin = null) {

--- a/src/ui/dock/DockRenderer.js
+++ b/src/ui/dock/DockRenderer.js
@@ -24,7 +24,7 @@ import Shell from 'gi://Shell';
 import { buildModules } from '../modules/DockModules.js';
 import WorkspaceFilter from '../../core/WorkspaceFilter.js';
 import { applyDynamicStyles, resolveTooltipColors } from './DockThemeResolver.js';
-import { isActorAlive, updateLayout, captureActorRect } from './DockLayoutEngine.js';
+import { isActorAlive, markActorDisposed, updateLayout, captureActorRect } from './DockLayoutEngine.js';
 import { createSeparator, buildAppButton, buildFolderButton } from './DockItemBuilder.js';
 import { setupMagnification, teardownMagnification, applyRealtimeFrame, resetMagnification } from '../magnifier/Magnifier.js';
 
@@ -348,10 +348,24 @@ export function renderDock(dockUI, forceRender = false) {
     endComponents.forEach(c => { applyOldVisuals(c); dockUI.boxActor.add_child(c); });
 
     if (dockUI.dockManager && dockUI.dockManager._externalActors) {
-        dockUI.dockManager._externalActors.forEach(extActor => {
-            if (isActorAlive(extActor)) {
+        const externals = dockUI.dockManager._externalActors;
+        // Snapshot: entries may be pruned while iterating.
+        Array.from(externals).forEach(extActor => {
+            if (!isActorAlive(extActor)) {
+                externals.delete(extActor);
+                return;
+            }
+            try {
                 applyOldVisuals(extActor);
-                dockUI.boxActor.add_child(extActor);
+                // A stolen actor is detached above via boxActor.remove_child;
+                // if its owner re-parented it in the meantime, don't fight.
+                const parent = extActor.get_parent();
+                if (parent && parent !== dockUI.boxActor) return;
+                if (!parent) dockUI.boxActor.add_child(extActor);
+            } catch (_e) {
+                // Disposed between the liveness check and use (issue #54).
+                markActorDisposed(extActor);
+                externals.delete(extActor);
             }
         });
     }


### PR DESCRIPTION
Fixes #54

## Problem

GNOME Shell crashed with SIGSEGV in `clutter_actor_remove_child` when a third-party actor stolen into the dock (e.g. Dynamic Music Pill's `MusicPill`) was disposed by its owner. The journal showed `clutter_actor_remove_child: assertion 'child->priv->parent != NULL' failed` followed by `Object Gjs_src_uiMusicPill_MusicPill has been already disposed`.

## Root cause

Two defects combined:

1. **Hijacked `remove_child` detached from the wrong parent.** The stolen actor is re-parented into `dockUI.boxActor`, but its owner still calls `origBox.remove_child(actor)` on teardown. The patched method forwarded this to the *native* remove on `origBox`, whose parent pointer for that child is `NULL` → assertion → NULL dereference.
2. **`_externalActors` was never pruned on disposal.** If the owner called `actor.destroy()` directly, the stale reference stayed in the Set. The next render pass ran `applyOldVisuals()` / `add_child()` on a disposed GObject, and `isActorAlive()` (`actor.visible !== undefined`) itself touched the disposed object.

## Fix

- **`DockLayoutEngine.isActorAlive()`** is now exception-safe and consults a `WeakSet` of known-disposed actors (`markActorDisposed`). A WeakSet is used instead of tagging the actor because expando properties on a disposed GObject wrapper are not reliable.
- **`DockManager`**
  - On steal, `connectObject('destroy', …)` on the actor so it is dropped from `_externalActors` the instant Clutter begins tearing it down, and a re-render is queued.
  - Hijacked `origBox.remove_child` now detaches from the actor's **actual** parent (`boxActor`), only falling through to the native remove when the parent really is `origBox`.
  - The 300 ms text-scanning checker snapshots the Set, prunes dead actors, and is wrapped in `try/catch`.
  - `releaseExternalWidget` / `_restoreGnomeDash` disconnect our signal handler and skip disposed actors.
  - Skip stealing actors that are already dead or already tracked.
- **`DockRenderer`** snapshots the Set before iterating, prunes dead entries, and wraps `applyOldVisuals`/`add_child` so a dispose between the liveness check and use cannot escalate into a native crash.

## Testing notes

Reproduce per the issue: enable `dhruva@narkagni` + `dynamic-music-pill@andbal`, play media over Bluetooth, then disconnect/reconnect the headphones (or switch MPRIS players). Previously the session was torn down; with this change the pill is removed from the dock and re-adopted when the extension recreates it. Also worth toggling **Independent dock** on/off a few times with the pill present to exercise `_restoreGnomeDash`.

All three files pass `node --check`. I don't have a GNOME session available in this environment, so a manual run on GNOME 50 is needed before merge.
