### PR TITLE
Fix scroll-action-app: cycle windows on running app icons

### DIFF
--- a/src/core/ScrollManager.js
+++ b/src/core/ScrollManager.js
@@ -21,10 +21,48 @@ import Clutter from 'gi://Clutter';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 
+function cycleAppWindows(windows, dir) {
+    if (!windows || windows.length === 0) return;
+
+    if (windows.length < 2) {
+        const target = windows[0];
+        target.unminimize();
+        Main.activateWindow(target);
+        return;
+    }
+
+    const focusWin = global.display.get_focus_window();
+    let idx = windows.indexOf(focusWin);
+    if (idx === -1) idx = 0;
+
+    let nextIdx = idx;
+    if (dir === Clutter.ScrollDirection.UP) {
+        nextIdx = (idx - 1 + windows.length) % windows.length;
+    } else if (dir === Clutter.ScrollDirection.DOWN) {
+        nextIdx = (idx + 1) % windows.length;
+    }
+
+    if (nextIdx !== idx) {
+        const target = windows[nextIdx];
+        target.unminimize();
+        Main.activateWindow(target);
+    }
+}
+
 export default class ScrollManager {
     static setupDockScroll(dockActor, settings) {
         dockActor.connectObject('scroll-event', (actor, event) => {
             actor._lastIconClickTime = Date.now();
+
+            const dockUI = actor._dockUI;
+            const hoveredBtn = dockUI ? dockUI._hoveredAppButton : null;
+            const hoveredApp = hoveredBtn && hoveredBtn._delegate ? hoveredBtn._delegate.app : null;
+
+            if (hoveredApp && settings.get_boolean('scroll-action-app')) {
+                const windows = hoveredApp.get_windows();
+                cycleAppWindows(windows, event.get_scroll_direction());
+                return Clutter.EVENT_STOP;
+            }
 
             if (!settings.get_boolean('scroll-action-dock')) return Clutter.EVENT_PROPAGATE;
 
@@ -55,34 +93,7 @@ export default class ScrollManager {
 
             if (!settings.get_boolean('scroll-action-app')) return Clutter.EVENT_STOP;
 
-            const dir = event.get_scroll_direction();
-            const windows = getWindowsFn();
-
-            if (!windows || windows.length === 0) return Clutter.EVENT_STOP;
-
-            if (windows.length < 2) {
-                const target = windows[0];
-                target.unminimize();
-                Main.activateWindow(target);
-                return Clutter.EVENT_STOP;
-            }
-
-            const focusWin = global.display.get_focus_window();
-            let idx = windows.indexOf(focusWin);
-            if (idx === -1) idx = 0;
-
-            let nextIdx = idx;
-            if (dir === Clutter.ScrollDirection.UP) {
-                nextIdx = (idx - 1 + windows.length) % windows.length;
-            } else if (dir === Clutter.ScrollDirection.DOWN) {
-                nextIdx = (idx + 1) % windows.length;
-            }
-
-            if (nextIdx !== idx) {
-                const target = windows[nextIdx];
-                target.unminimize();
-                Main.activateWindow(target);
-            }
+            cycleAppWindows(getWindowsFn(), event.get_scroll_direction());
             return Clutter.EVENT_STOP;
         }, appButton);
     }

--- a/src/ui/dock/DockItemBuilder.js
+++ b/src/ui/dock/DockItemBuilder.js
@@ -32,6 +32,7 @@ import { animateIconClick } from '../effects/IconClickEffect.js';
 import { setupDragAndDrop, applyIconFilter } from '../DragDrop.js';
 import { setMagnifierPauseState } from '../magnifier/MagnifierState.js';
 import { animateMinimize, animateRestore } from '../effects/WindowEffects.js';
+import ScrollManager from '../../core/ScrollManager.js';
 
 
 export function createSeparator(dockUI, iconSize, isVerticalDock, type = 'module', sepId = 'dhruva-sep-default') {
@@ -227,6 +228,9 @@ export function buildAppButton(dockUI, app, isRunning, finalActiveWindows, indPr
     btn._baseBg = baseBg;
 
     btn.connectObject('notify::hover', () => {
+        if (btn.hover) dockUI._hoveredAppButton = btn;
+        else if (dockUI._hoveredAppButton === btn) dockUI._hoveredAppButton = null;
+
         if (dockUI.settings.get_boolean('hover-zoom')) return;
 
         const expanded = (isRunning && showIndicators) || btn.hover;
@@ -285,6 +289,8 @@ export function buildAppButton(dockUI, app, isRunning, finalActiveWindows, indPr
         }
         return Clutter.EVENT_PROPAGATE;
     }, btn);
+
+    ScrollManager.setupAppScroll(btn, () => app.get_windows(), dockUI.settings);
 
     btn._activateCallback = (buttonNum, state = 0) => {
         const isCtrl = (state & Clutter.ModifierType.CONTROL_MASK) !== 0;


### PR DESCRIPTION
## Summary
- `scroll-action-app` was only wired up on the folder-grouping buttons (Trash, Home, custom folders), not on the regular running-app icons built in `DockItemBuilder.js`. Scrolling over a running app (e.g. multiple Chrome windows) always fell through to the dock's own scroll handler and just switched workspace instead of cycling windows.
- Root cause: the dock's outer actor scroll-event handler consumes the scroll before it can reach a per-icon handler on this GNOME Shell version, so a `scroll-event` connected directly on the app button never fires.
- Fix: track the currently hovered app button on `DockUI` (`_hoveredAppButton`), and resolve it inside the existing dock-level `scroll-event` handler in `ScrollManager.setupDockScroll`. If the pointer is over a running app and `scroll-action-app` is enabled, cycle that app's windows; otherwise fall back to the existing `scroll-action-dock` workspace-switch behavior.
- Extracted the window-cycling logic into a shared `cycleAppWindows()` helper reused by both `setupDockScroll` and the existing `setupAppScroll` (kept for the folder buttons that already worked).

Tested manually on GNOME Shell 49.9 (Fedora 43, Wayland): scrolling over a running app with multiple windows now cycles through them; scrolling over dock empty space / non-hovered apps still switches workspace as before.

## Test plan
- [ ] Enable `scroll-action-app` in preferences
- [ ] Open 2+ windows of the same app (e.g. a browser)
- [ ] Hover the app's dock icon and scroll — windows should cycle
- [ ] Scroll over empty dock space with `scroll-action-dock` enabled — workspace should still switch